### PR TITLE
Update BetterSpec.groovy

### DIFF
--- a/chapter1/src/test/groovy/com/manning/spock/chapter1/BetterSpec.groovy
+++ b/chapter1/src/test/groovy/com/manning/spock/chapter1/BetterSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.*
 
 
 class BetterSpec extends spock.lang.Specification{
-	def "Client should have a bonus if he spents more than 100 dollars"() {
+	def "Client should have a bonus if he spends more than 100 dollars"() {
 		when: "a client buys something with value at least 100"
 		def client = new Client();
 		def billing = new CreditCardBilling();


### PR DESCRIPTION
Corrected spelling from spents to spends.
